### PR TITLE
cherry-pick fs/fat fixes from mainline u-boot

### DIFF
--- a/common/cmd_fat.c
+++ b/common/cmd_fat.c
@@ -120,15 +120,15 @@ int do_fat_exist (cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 		printf ("usage: fatexist <interface> <dev[:part]> <filepath>\n");
 		return 1;
 	}
-	dev = (int)simple_strtoul (argv[2], &ep, 16);
-	dev_desc=get_dev(argv[1],dev);
-	if (dev_desc==NULL) {
-		puts ("\n** Invalid boot device **\n");
+	dev = (int)simple_strtoul(argv[2], &ep, 16);
+	dev_desc = get_dev(argv[1],dev);
+	if (dev_desc == NULL) {
+		puts("\n** Invalid boot device **\n");
 		return 1;
 	}
 	if (*ep) {
 		if (*ep != ':') {
-			puts ("\n** Invalid boot device, use `dev[:part]' **\n");
+			puts("\n** Invalid boot device, use `dev[:part]' **\n");
 			return 1;
 		}
 		part = (int)simple_strtoul(++ep, NULL, 16);
@@ -175,7 +175,7 @@ int do_fat_ls (cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 		return 0;
 	}
 	dev = (int)simple_strtoul(argv[2], &ep, 16);
-	dev_desc = get_dev(argv[1],dev);
+	dev_desc = get_dev(argv[1], dev);
 	if (dev_desc == NULL) {
 		puts("\n** Invalid boot device **\n");
 		return 1;
@@ -256,11 +256,11 @@ int do_fat_format(cmd_tbl_t *cmdtp, int flag, int argc, char *argv[])
         block_dev_desc_t *dev_desc = NULL;
 
         if (argc < 2) {
-                printf ("usage : fatformat <interface> <dev[:part]>\n");
+                printf("usage : fatformat <interface> <dev[:part]>\n");
                 return(0);
         }
 
-        dev = (int)simple_strtoul (argv[2], &ep, 16);
+        dev = (int)simple_strtoul(argv[2], &ep, 16);
         dev_desc = get_dev(argv[1], dev);
 
         if (dev_desc == NULL) {
@@ -270,12 +270,12 @@ int do_fat_format(cmd_tbl_t *cmdtp, int flag, int argc, char *argv[])
 
         if (*ep) {
                 if (*ep != ':') {
-                        puts ("\n **Invald boot device,use 'dev[:part]'**\n");
+                        puts("\n **Invald boot device,use 'dev[:part]'**\n");
                         return 1;
                 }
                 part = (int)simple_strtoul(++ep, NULL, 16);
                 if (part > 4 || part <1) {
-                        puts ("** Partition Number should be 1 ~ 4 **\n");
+                        puts("** Partition Number should be 1 ~ 4 **\n");
                 }
         }
 

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -34,8 +34,7 @@
 /*
  * Convert a string to lowercase.
  */
-static void
-downcase(char *str)
+static void downcase (char *str)
 {
 	while (*str != '\0') {
 		TOLOWER(*str);
@@ -43,44 +42,48 @@ downcase(char *str)
 	}
 }
 
-static  block_dev_desc_t *cur_dev = NULL;
+static block_dev_desc_t *cur_dev = NULL;
+
 static unsigned long part_offset = 0;
+
 static int cur_part = 1;
 
-#define DOS_PART_TBL_OFFSET		0x1be
-#define DOS_PART_MAGIC_OFFSET	0x1fe
-#define FAT_FS_TYPE_OFFSET		0x36
-#define FAT32_FS_TYPE_OFFSET		0x52
+#define DOS_PART_MAGIC_OFFSET		0x1fe
+#define DOS_FS_TYPE_OFFSET		0x36
+#define DOS_FS32_TYPE_OFFSET		0x52
 
-int disk_read (__u32 startblock, __u32 getsize, __u8 * bufptr)
+static int disk_read (__u32 startblock, __u32 getsize, __u8 * bufptr)
 {
-	startblock += part_offset;
 	if (cur_dev == NULL)
 		return -1;
+
+	startblock += part_offset;
+
 	if (cur_dev->block_read) {
-		return cur_dev->block_read (cur_dev->dev
-			, startblock, getsize, (unsigned long *)bufptr);
+		return cur_dev->block_read(cur_dev->dev, startblock, getsize,
+					   (unsigned long *) bufptr);
 	}
 	return -1;
 }
 
-
-int
-fat_register_device(block_dev_desc_t *dev_desc, int part_no)
+int fat_register_device (block_dev_desc_t * dev_desc, int part_no)
 {
 	unsigned char buffer[SECTOR_SIZE];
+
 	disk_partition_t info;
 
 	if (!dev_desc->block_read)
 		return -1;
+
 	cur_dev = dev_desc;
 	/* check if we have a MBR (on floppies we have only a PBR) */
-	if (dev_desc->block_read (dev_desc->dev, 0, 1, (ulong *) buffer) != 1) {
-		printf ("** Can't read from device %d **\n", dev_desc->dev);
+	if (dev_desc->block_read(dev_desc->dev, 0, 1, (ulong *)buffer) != 1) {
+		printf("** Can't read from device %d **\n",
+			dev_desc->dev);
 		return -1;
 	}
 	if (buffer[DOS_PART_MAGIC_OFFSET] != 0x55 ||
-		buffer[DOS_PART_MAGIC_OFFSET + 1] != 0xaa) {
+	    buffer[DOS_PART_MAGIC_OFFSET + 1] != 0xaa) {
 		/* no signature found */
 		return -1;
 	}
@@ -90,32 +93,35 @@ fat_register_device(block_dev_desc_t *dev_desc, int part_no)
      defined(CONFIG_CMD_USB) || \
      defined(CONFIG_MMC) || \
      defined(CONFIG_SYSTEMACE) )
-	/* First we assume, there is a MBR */
-	if (!get_partition_info (dev_desc, part_no, &info)) {
+	/* First we assume there is a MBR */
+	if (!get_partition_info(dev_desc, part_no, &info)) {
 		part_offset = info.start;
 		cur_part = part_no;
-		if (dev_desc->block_read (dev_desc->dev, part_offset, 1, (ulong *) buffer) != 1) {
-			if (dev_desc->block_read (dev_desc->dev, 0, 1, (ulong *) buffer) != 1) {
+		if (dev_desc->block_read (dev_desc->dev, part_offset, 1, (ulong *)buffer) != 1) {
+			if (dev_desc->block_read (dev_desc->dev, 0, 1, (ulong *)buffer) != 1) {
 				printf ("** Can't read from device %d **\n", dev_desc->dev);
 				return -1;
 			}
 			cur_part = 1;
 			part_offset = 0;
 		}
-		if (strncmp((char *)&buffer[FAT_FS_TYPE_OFFSET], "FAT", 3) && strncmp((char *)&buffer[FAT32_FS_TYPE_OFFSET],"FAT",3))
-			return -1;			
-	} else if (!strncmp((char *)&buffer[FAT_FS_TYPE_OFFSET], "FAT", 3) || !strncmp((char *)&buffer[FAT32_FS_TYPE_OFFSET],"FAT",3)) {
+		if (strncmp((char *)&buffer[DOS_FS_TYPE_OFFSET], "FAT", 3) != 0 &&
+		    strncmp((char *)&buffer[DOS_FS32_TYPE_OFFSET], "FAT32", 3) != 0)
+			return -1;
+	} else if ((strncmp((char *)&buffer[DOS_FS_TYPE_OFFSET], "FAT", 3) == 0) ||
+		   (strncmp((char *)&buffer[DOS_FS32_TYPE_OFFSET], "FAT32", 5) == 0)) {
 		/* ok, we assume we are on a PBR only */
 		cur_part = 1;
 		part_offset = 0;
 	} else {
-		printf ("** Partition %d not valid on device %d **\n",
-				part_no, dev_desc->dev);
+		printf("** Partition %d not valid on device %d **\n",
+			part_no, dev_desc->dev);
 		return -1;
 	}
 
 #else
-	if (!strncmp((char *)&buffer[FAT_FS_TYPE_OFFSET],"FAT",3) || !strncmp((char *)&buffer[FAT32_FS_TYPE_OFFSET],"FAT",3)) {
+	if (strncmp((char *)&buffer[DOS_FS_TYPE_OFFSET], "FAT", 3) == 0 ||
+	    strncmp((char *)&buffer[DOS_FS32_TYPE_OFFSET], "FAT32", 3) == 0) {
 		/* ok, we assume we are on a PBR only */
 		cur_part = 1;
 		part_offset = 0;
@@ -323,8 +329,7 @@ static int write_reserved(block_dev_desc_t *dev_desc, disk_partition_t *info)
         return 1;
 }
 
-static int write_fat(block_dev_desc_t *dev_desc, disk_partition_t *info, int
-fat_size)
+static int write_fat(block_dev_desc_t *dev_desc, disk_partition_t *info, int fat_size)
 {
         __u8 *dummy;
         __u8 *img;
@@ -421,12 +426,12 @@ int fat_format_device(block_dev_desc_t *dev_desc, int part_no)
         if (!get_partition_info (dev_desc, part_no, &info)) {
                 part_offset = info.start;
                 cur_part = part_no;
-        } else if (!strncmp((char *)&buffer[FAT_FS_TYPE_OFFSET], "FAT", 3)) {
+        } else if (strncmp((char *)&buffer[DOS_FS_TYPE_OFFSET], "FAT", 3) == 0) {
                 /* ok, we assume we are on a PBR only */
                 cur_part = 1;
                 part_offset = 0;
         } else {
-                printf ("** Partition %d not valid on device %d **\n",
+                printf("** Partition %d not valid on device %d **\n",
                                 part_no, dev_desc->dev);
                 return -1;
         }
@@ -452,13 +457,13 @@ int fat_format_device(block_dev_desc_t *dev_desc, int part_no)
  * Get the first occurence of a directory delimiter ('/' or '\') in a string.
  * Return index into string if found, -1 otherwise.
  */
-static int
-dirdelim(char *str)
+static int dirdelim (char *str)
 {
 	char *start = str;
 
 	while (*str != '\0') {
-		if (ISDIRDELIM(*str)) return str - start;
+		if (ISDIRDELIM(*str))
+			return str - start;
 		str++;
 	}
 	return -1;
@@ -469,10 +474,9 @@ dirdelim(char *str)
  * Match volume_info fs_type strings.
  * Return 0 on match, -1 otherwise.
  */
-static int
-compare_sign(char *str1, char *str2)
+static int compare_sign(char *str1, char *str2)
 {
-	char *end = str1+SIGNLEN;
+	char *end = str1 + SIGNLEN;
 
 	while (str1 != end) {
 		if (*str1 != *str2) {
@@ -489,11 +493,11 @@ compare_sign(char *str1, char *str2)
 /*
  * Extract zero terminated short name from a directory entry.
  */
-static void get_name (dir_entry *dirent, char *s_name)
+static void get_name(dir_entry *dirent, char *s_name)
 {
 	char *ptr;
 
-	memcpy (s_name, dirent->name, 8);
+	memcpy(s_name, dirent->name, 8);
 	s_name[8] = '\0';
 	ptr = s_name;
 	while (*ptr && *ptr != ' ')
@@ -501,7 +505,7 @@ static void get_name (dir_entry *dirent, char *s_name)
 	if (dirent->ext[0] && dirent->ext[0] != ' ') {
 		*ptr = '.';
 		ptr++;
-		memcpy (ptr, dirent->ext, 3);
+		memcpy(ptr, dirent->ext, 3);
 		ptr[3] = '\0';
 		while (*ptr && *ptr != ' ')
 			ptr++;
@@ -511,19 +515,19 @@ static void get_name (dir_entry *dirent, char *s_name)
 		*s_name = '\0';
 	else if (*s_name == aRING)
 		*s_name = DELETED_FLAG;
-	downcase (s_name);
+	downcase(s_name);
 }
 
 /*
  * Get the entry at index 'entry' in a FAT (12/16/32) table.
  * On failure 0x00 is returned.
  */
-static __u32
-get_fatent(fsdata *mydata, __u32 entry)
+static __u32 get_fatent (fsdata *mydata, __u32 entry)
 {
 	__u32 bufnum;
-	__u32 offset;
+	__u32 off16, offset;
 	__u32 ret = 0x00;
+	__u16 val1, val2;
 
 	switch (mydata->fatsize) {
 	case 32:
@@ -544,12 +548,12 @@ get_fatent(fsdata *mydata, __u32 entry)
 		return ret;
 	}
 
-	FAT_DPRINT("FAT%d: entry: 0x%04x = %d, offset: 0x%04x = %d\n",
-		mydata->fatsize, entry, entry, offset, offset);
+	debug("FAT%d: entry: 0x%04x = %d, offset: 0x%04x = %d\n",
+	       mydata->fatsize, entry, entry, offset, offset);
 
 	/* Read a new block of FAT entries into the cache. */
 	if (bufnum != mydata->fatbufnum) {
-		int getsize = FATBUFSIZE/FS_BLOCK_SIZE;
+		int getsize = FATBUFSIZE / FS_BLOCK_SIZE;
 		__u8 *bufptr = mydata->fatbuf;
 		__u32 fatlength = mydata->fatlength;
 		__u32 startblock = bufnum * FATBUFBLOCKS;
@@ -557,9 +561,10 @@ get_fatent(fsdata *mydata, __u32 entry)
 		fatlength *= SECTOR_SIZE;	/* We want it in bytes now */
 		startblock += mydata->fat_sect;	/* Offset from start of disk */
 
-		if (getsize > fatlength) getsize = fatlength;
+		if (getsize > fatlength)
+			getsize = fatlength;
 		if (disk_read(startblock, getsize, bufptr) < 0) {
-			FAT_DPRINT("Error reading FAT blocks\n");
+			debug("Error reading FAT blocks\n");
 			return ret;
 		}
 		mydata->fatbufnum = bufnum;
@@ -568,80 +573,81 @@ get_fatent(fsdata *mydata, __u32 entry)
 	/* Get the actual entry from the table */
 	switch (mydata->fatsize) {
 	case 32:
-		ret = FAT2CPU32(((__u32*)mydata->fatbuf)[offset]);
+		ret = FAT2CPU32(((__u32 *) mydata->fatbuf)[offset]);
 		break;
 	case 16:
-		ret = FAT2CPU16(((__u16*)mydata->fatbuf)[offset]);
+		ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[offset]);
 		break;
-	case 12: {
-		__u32 off16 = (offset*3)/4;
-		__u16 val1, val2;
+	case 12:
+		off16 = (offset * 3) / 4;
 
 		switch (offset & 0x3) {
 		case 0:
-			ret = FAT2CPU16(((__u16*)mydata->fatbuf)[off16]);
+			ret = FAT2CPU16(((__u16 *) mydata->fatbuf)[off16]);
 			ret &= 0xfff;
 			break;
 		case 1:
-			val1 = FAT2CPU16(((__u16*)mydata->fatbuf)[off16]);
+			val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
 			val1 &= 0xf000;
-			val2 = FAT2CPU16(((__u16*)mydata->fatbuf)[off16+1]);
+			val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
 			val2 &= 0x00ff;
 			ret = (val2 << 4) | (val1 >> 12);
 			break;
 		case 2:
-			val1 = FAT2CPU16(((__u16*)mydata->fatbuf)[off16]);
+			val1 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
 			val1 &= 0xff00;
-			val2 = FAT2CPU16(((__u16*)mydata->fatbuf)[off16+1]);
+			val2 = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16 + 1]);
 			val2 &= 0x000f;
 			ret = (val2 << 8) | (val1 >> 8);
 			break;
 		case 3:
-			ret = FAT2CPU16(((__u16*)mydata->fatbuf)[off16]);;
+			ret = FAT2CPU16(((__u16 *)mydata->fatbuf)[off16]);
 			ret = (ret & 0xfff0) >> 4;
 			break;
 		default:
 			break;
 		}
+		break;
 	}
-	break;
-	}
-	FAT_DPRINT("FAT%d: ret: %08x, offset: %04x\n",
-		mydata->fatsize, ret, offset);
+	debug("FAT%d: ret: %08x, offset: %04x\n",
+	       mydata->fatsize, ret, offset);
 
 	return ret;
 }
-
 
 /*
  * Read at most 'size' bytes from the specified cluster into 'buffer'.
  * Return 0 on success, -1 otherwise.
  */
 static int
-get_cluster(fsdata *mydata, __u32 clustnum, __u8 *buffer, unsigned long size)
+get_cluster (fsdata *mydata, __u32 clustnum, __u8 *buffer,
+	     unsigned long size)
 {
 	int idx = 0;
 	__u32 startsect;
 
 	if (clustnum > 0) {
-		startsect = mydata->data_begin + clustnum*mydata->clust_size;
+		startsect = mydata->data_begin +
+				clustnum * mydata->clust_size;
 	} else {
 		startsect = mydata->rootdir_sect;
 	}
 
-	FAT_DPRINT("gc - clustnum: %d, startsect: %d\n", clustnum, startsect);
-	if (disk_read(startsect, size/FS_BLOCK_SIZE , buffer) < 0) {
-		FAT_DPRINT("Error reading data\n");
+	debug("gc - clustnum: %d, startsect: %d\n", clustnum, startsect);
+
+	if (disk_read(startsect, size / FS_BLOCK_SIZE, buffer) < 0) {
+		debug("Error reading data\n");
 		return -1;
 	}
-	if(size % FS_BLOCK_SIZE) {
+	if (size % FS_BLOCK_SIZE) {
 		__u8 tmpbuf[FS_BLOCK_SIZE];
-		idx= size/FS_BLOCK_SIZE;
+
+		idx = size / FS_BLOCK_SIZE;
 		if (disk_read(startsect + idx, 1, tmpbuf) < 0) {
-			FAT_DPRINT("Error reading data\n");
+			debug("Error reading data\n");
 			return -1;
 		}
-		buffer += idx*FS_BLOCK_SIZE;
+		buffer += idx * FS_BLOCK_SIZE;
 
 		memcpy(buffer, tmpbuf, size % FS_BLOCK_SIZE);
 		return 0;
@@ -650,15 +656,14 @@ get_cluster(fsdata *mydata, __u32 clustnum, __u8 *buffer, unsigned long size)
 	return 0;
 }
 
-
 /*
  * Read at most 'maxsize' bytes from the file associated with 'dentptr'
  * into 'buffer'.
  * Return the number of bytes read or -1 on fatal errors.
  */
 static long
-get_contents(fsdata *mydata, dir_entry *dentptr, __u8 *buffer,
-	     unsigned long maxsize)
+get_contents (fsdata *mydata, dir_entry *dentptr, __u8 *buffer,
+	      unsigned long maxsize)
 {
 	unsigned long filesize = FAT2CPU32(dentptr->size), gotsize = 0;
 	unsigned int bytesperclust = mydata->clust_size * SECTOR_SIZE;
@@ -666,65 +671,70 @@ get_contents(fsdata *mydata, dir_entry *dentptr, __u8 *buffer,
 	__u32 endclust, newclust;
 	unsigned long actsize;
 
-	FAT_DPRINT("Filesize: %ld bytes\n", filesize);
+	debug("Filesize: %ld bytes\n", filesize);
 
-	if (maxsize > 0 && filesize > maxsize) filesize = maxsize;
+	if (maxsize > 0 && filesize > maxsize)
+		filesize = maxsize;
 
-	FAT_DPRINT("%ld bytes\n", filesize);
+	debug("%ld bytes\n", filesize);
 
-	actsize=bytesperclust;
-	endclust=curclust;
+	actsize = bytesperclust;
+	endclust = curclust;
+
 	do {
 		/* search for consecutive clusters */
-		while(actsize < filesize) {
+		while (actsize < filesize) {
 			newclust = get_fatent(mydata, endclust);
-			if((newclust -1)!=endclust)
+			if ((newclust - 1) != endclust)
 				goto getit;
 			if (CHECK_CLUST(newclust, mydata->fatsize)) {
-				FAT_DPRINT("curclust: 0x%x\n", newclust);
-				FAT_DPRINT("Invalid FAT entry\n");
+				debug("curclust: 0x%x\n", newclust);
+				debug("Invalid FAT entry\n");
 				return gotsize;
 			}
-			endclust=newclust;
-			actsize+= bytesperclust;
+			endclust = newclust;
+			actsize += bytesperclust;
 		}
+
 		/* actsize >= file size */
 		actsize -= bytesperclust;
+
 		/* get remaining clusters */
 		if (get_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
-			FAT_ERROR("Error reading cluster\n");
+			printf("Error reading cluster\n");
 			return -1;
 		}
+
 		/* get remaining bytes */
 		gotsize += (int)actsize;
 		filesize -= actsize;
 		buffer += actsize;
-		actsize= filesize;
+		actsize = filesize;
 		if (get_cluster(mydata, endclust, buffer, (int)actsize) != 0) {
-			FAT_ERROR("Error reading cluster\n");
+			printf("Error reading cluster\n");
 			return -1;
 		}
-		gotsize+=actsize;
+		gotsize += actsize;
 		return gotsize;
 getit:
 		if (get_cluster(mydata, curclust, buffer, (int)actsize) != 0) {
-			FAT_ERROR("Error reading cluster\n");
+			printf("Error reading cluster\n");
 			return -1;
 		}
 		gotsize += (int)actsize;
 		filesize -= actsize;
 		buffer += actsize;
+
 		curclust = get_fatent(mydata, endclust);
 		if (CHECK_CLUST(curclust, mydata->fatsize)) {
-			FAT_DPRINT("curclust: 0x%x\n", curclust);
-			FAT_ERROR("Invalid FAT entry\n");
+			debug("curclust: 0x%x\n", curclust);
+			printf("Invalid FAT entry\n");
 			return gotsize;
 		}
-		actsize=bytesperclust;
-		endclust=curclust;
+		actsize = bytesperclust;
+		endclust = curclust;
 	} while (1);
 }
-
 
 #ifdef CONFIG_SUPPORT_VFAT
 /*
@@ -732,30 +742,31 @@ getit:
  * starting at l_name[*idx].
  * Return 1 if terminator (zero byte) is found, 0 otherwise.
  */
-static int
-slot2str(dir_slot *slotptr, char *l_name, int *idx)
+static int slot2str (dir_slot *slotptr, char *l_name, int *idx)
 {
 	int j;
 
 	for (j = 0; j <= 8; j += 2) {
 		l_name[*idx] = slotptr->name0_4[j];
-		if (l_name[*idx] == 0x00) return 1;
+		if (l_name[*idx] == 0x00)
+			return 1;
 		(*idx)++;
 	}
 	for (j = 0; j <= 10; j += 2) {
 		l_name[*idx] = slotptr->name5_10[j];
-		if (l_name[*idx] == 0x00) return 1;
+		if (l_name[*idx] == 0x00)
+			return 1;
 		(*idx)++;
 	}
 	for (j = 0; j <= 2; j += 2) {
 		l_name[*idx] = slotptr->name11_12[j];
-		if (l_name[*idx] == 0x00) return 1;
+		if (l_name[*idx] == 0x00)
+			return 1;
 		(*idx)++;
 	}
 
 	return 0;
 }
-
 
 /*
  * Extract the full long filename starting at 'retdent' (which is really
@@ -763,64 +774,71 @@ slot2str(dir_slot *slotptr, char *l_name, int *idx)
  * into 'retdent'
  * Return 0 on success, -1 otherwise.
  */
-__attribute__ ((__aligned__(__alignof__(dir_entry))))
+__attribute__ ((__aligned__ (__alignof__ (dir_entry))))
 __u8 get_vfatname_block[MAX_CLUSTSIZE];
+
 static int
-get_vfatname(fsdata *mydata, int curclust, __u8 *cluster,
-	     dir_entry *retdent, char *l_name)
+get_vfatname (fsdata *mydata, int curclust, __u8 *cluster,
+	      dir_entry *retdent, char *l_name)
 {
 	dir_entry *realdent;
-	dir_slot  *slotptr = (dir_slot*) retdent;
-	__u8	  *nextclust = cluster + mydata->clust_size * SECTOR_SIZE;
-	__u8	   counter = (slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff;
+	dir_slot *slotptr = (dir_slot *)retdent;
+	__u8 *nextclust = cluster + mydata->clust_size * SECTOR_SIZE;
+	__u8 counter = (slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff;
 	int idx = 0;
 
-	while ((__u8*)slotptr < nextclust) {
-		if (counter == 0) break;
+	while ((__u8 *)slotptr < nextclust) {
+		if (counter == 0)
+			break;
 		if (((slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff) != counter)
 			return -1;
 		slotptr++;
 		counter--;
 	}
 
-	if ((__u8*)slotptr >= nextclust) {
+	if ((__u8 *)slotptr >= nextclust) {
 		dir_slot *slotptr2;
 
 		slotptr--;
 		curclust = get_fatent(mydata, curclust);
 		if (CHECK_CLUST(curclust, mydata->fatsize)) {
-			FAT_DPRINT("curclust: 0x%x\n", curclust);
-			FAT_ERROR("Invalid FAT entry\n");
+			debug("curclust: 0x%x\n", curclust);
+			printf("Invalid FAT entry\n");
 			return -1;
 		}
+
 		if (get_cluster(mydata, curclust, get_vfatname_block,
 				mydata->clust_size * SECTOR_SIZE) != 0) {
-			FAT_DPRINT("Error: reading directory block\n");
+			debug("Error: reading directory block\n");
 			return -1;
 		}
-		slotptr2 = (dir_slot*) get_vfatname_block;
-		while (slotptr2->id > 0x01) {
+
+		slotptr2 = (dir_slot *)get_vfatname_block;
+		while (slotptr2->id > 0x01)
 			slotptr2++;
-		}
+
 		/* Save the real directory entry */
-		realdent = (dir_entry*)slotptr2 + 1;
-		while ((__u8*)slotptr2 >= get_vfatname_block) {
+		realdent = (dir_entry *)slotptr2 + 1;
+		while ((__u8 *)slotptr2 >= get_vfatname_block) {
 			slot2str(slotptr2, l_name, &idx);
 			slotptr2--;
 		}
 	} else {
 		/* Save the real directory entry */
-		realdent = (dir_entry*)slotptr;
+		realdent = (dir_entry *)slotptr;
 	}
 
 	do {
 		slotptr--;
-		if (slot2str(slotptr, l_name, &idx)) break;
+		if (slot2str(slotptr, l_name, &idx))
+			break;
 	} while (!(slotptr->id & LAST_LONG_ENTRY_MASK));
 
 	l_name[idx] = '\0';
-	if (*l_name == DELETED_FLAG) *l_name = '\0';
-	else if (*l_name == aRING) *l_name = DELETED_FLAG;
+	if (*l_name == DELETED_FLAG)
+		*l_name = '\0';
+	else if (*l_name == aRING)
+		*l_name = DELETED_FLAG;
 	downcase(l_name);
 
 	/* Return the real directory entry */
@@ -829,207 +847,220 @@ get_vfatname(fsdata *mydata, int curclust, __u8 *cluster,
 	return 0;
 }
 
-
 /* Calculate short name checksum */
-static __u8
-mkcksum(const char *str)
+static __u8 mkcksum (const char *str)
 {
 	int i;
+
 	__u8 ret = 0;
 
 	for (i = 0; i < 11; i++) {
-		ret = (((ret&1)<<7)|((ret&0xfe)>>1)) + str[i];
+		ret = (((ret & 1) << 7) | ((ret & 0xfe) >> 1)) + str[i];
 	}
 
 	return ret;
 }
-#endif
-
+#endif	/* CONFIG_SUPPORT_VFAT */
 
 /*
  * Get the directory entry associated with 'filename' from the directory
  * starting at 'startsect'
  */
-__attribute__ ((__aligned__(__alignof__(dir_entry))))
+__attribute__ ((__aligned__ (__alignof__ (dir_entry))))
 __u8 get_dentfromdir_block[MAX_CLUSTSIZE];
-static dir_entry *get_dentfromdir (fsdata * mydata, int startsect,
-				   char *filename, dir_entry * retdent,
+
+static dir_entry *get_dentfromdir (fsdata *mydata, int startsect,
+				   char *filename, dir_entry *retdent,
 				   int dols)
 {
-    __u16 prevcksum = 0xffff;
-    __u32 curclust = START (retdent);
-    int files = 0, dirs = 0;
+	__u16 prevcksum = 0xffff;
+	__u32 curclust = START(retdent);
+	int files = 0, dirs = 0;
 
-    FAT_DPRINT ("get_dentfromdir: %s\n", filename);
-    while (1) {
-	dir_entry *dentptr;
-	int i;
+	debug("get_dentfromdir: %s\n", filename);
 
-	if (get_cluster (mydata, curclust, get_dentfromdir_block,
-		 mydata->clust_size * SECTOR_SIZE) != 0) {
-	    FAT_DPRINT ("Error: reading directory block\n");
-	    return NULL;
-	}
-	dentptr = (dir_entry *) get_dentfromdir_block;
-	for (i = 0; i < DIRENTSPERCLUST; i++) {
-	    char s_name[14], l_name[256];
+	while (1) {
+		dir_entry *dentptr;
 
-	    l_name[0] = '\0';
-	    if (dentptr->name[0] == DELETED_FLAG) {
-		    dentptr++;
-		    continue;
-	    }
-	    if ((dentptr->attr & ATTR_VOLUME)) {
-#ifdef CONFIG_SUPPORT_VFAT
-		if ((dentptr->attr & ATTR_VFAT) &&
-		    (dentptr->name[0] & LAST_LONG_ENTRY_MASK)) {
-		    prevcksum = ((dir_slot *) dentptr)
-			    ->alias_checksum;
-		    get_vfatname (mydata, curclust, get_dentfromdir_block,
-				  dentptr, l_name);
-		    if (dols) {
-			int isdir = (dentptr->attr & ATTR_DIR);
-			char dirc;
-			int doit = 0;
+		int i;
 
-			if (isdir) {
-			    dirs++;
-			    dirc = '/';
-			    doit = 1;
-			} else {
-			    dirc = ' ';
-			    if (l_name[0] != 0) {
-				files++;
-				doit = 1;
-			    }
+		if (get_cluster(mydata, curclust, get_dentfromdir_block,
+				mydata->clust_size * SECTOR_SIZE) != 0) {
+			debug("Error: reading directory block\n");
+			return NULL;
+		}
+
+		dentptr = (dir_entry *)get_dentfromdir_block;
+
+		for (i = 0; i < DIRENTSPERCLUST; i++) {
+			char s_name[14], l_name[256];
+
+			l_name[0] = '\0';
+			if (dentptr->name[0] == DELETED_FLAG) {
+				dentptr++;
+				continue;
 			}
-			if (doit) {
-			    if (dirc == ' ') {
-				printf (" %8ld   %s%c\n",
-					(long) FAT2CPU32 (dentptr->size),
-					l_name, dirc);
-			    } else {
-				printf ("            %s%c\n", l_name, dirc);
-			    }
-			}
-			dentptr++;
-			continue;
-		    }
-		    FAT_DPRINT ("vfatname: |%s|\n", l_name);
-		} else
-#endif
-		{
-		    /* Volume label or VFAT entry */
-		    dentptr++;
-		    continue;
-		}
-	    }
-	    if (dentptr->name[0] == 0) {
-		if (dols) {
-		    printf ("\n%d file(s), %d dir(s)\n\n", files, dirs);
-		}
-		FAT_DPRINT ("Dentname == NULL - %d\n", i);
-		return NULL;
-	    }
+			if ((dentptr->attr & ATTR_VOLUME)) {
 #ifdef CONFIG_SUPPORT_VFAT
-	    if (dols && mkcksum (dentptr->name) == prevcksum) {
-		dentptr++;
-		continue;
-	    }
+				if ((dentptr->attr & ATTR_VFAT) &&
+				    (dentptr-> name[0] & LAST_LONG_ENTRY_MASK)) {
+					prevcksum = ((dir_slot *)dentptr)->alias_checksum;
+					get_vfatname(mydata, curclust,
+						     get_dentfromdir_block,
+						     dentptr, l_name);
+					if (dols) {
+						int isdir;
+						char dirc;
+						int doit = 0;
+
+						isdir = (dentptr->attr & ATTR_DIR);
+
+						if (isdir) {
+							dirs++;
+							dirc = '/';
+							doit = 1;
+						} else {
+							dirc = ' ';
+							if (l_name[0] != 0) {
+								files++;
+								doit = 1;
+							}
+						}
+						if (doit) {
+							if (dirc == ' ') {
+								printf(" %8ld   %s%c\n",
+									(long)FAT2CPU32(dentptr->size),
+									l_name,
+									dirc);
+							} else {
+								printf("            %s%c\n",
+									l_name,
+									dirc);
+							}
+						}
+						dentptr++;
+						continue;
+					}
+					debug("vfatname: |%s|\n", l_name);
+				} else
 #endif
-	    get_name (dentptr, s_name);
-	    if (dols) {
-		int isdir = (dentptr->attr & ATTR_DIR);
-		char dirc;
-		int doit = 0;
+				{
+					/* Volume label or VFAT entry */
+					dentptr++;
+					continue;
+				}
+			}
+			if (dentptr->name[0] == 0) {
+				if (dols) {
+					printf("\n%d file(s), %d dir(s)\n\n",
+						files, dirs);
+				}
+				debug("Dentname == NULL - %d\n", i);
+				return NULL;
+			}
+#ifdef CONFIG_SUPPORT_VFAT
+			if (dols && mkcksum(dentptr->name) == prevcksum) {
+				dentptr++;
+				continue;
+			}
+#endif
+			get_name(dentptr, s_name);
+			if (dols) {
+				int isdir = (dentptr->attr & ATTR_DIR);
+				char dirc;
+				int doit = 0;
 
-		if (isdir) {
-		    dirs++;
-		    dirc = '/';
-		    doit = 1;
-		} else {
-		    dirc = ' ';
-		    if (s_name[0] != 0) {
-			files++;
-			doit = 1;
-		    }
+				if (isdir) {
+					dirs++;
+					dirc = '/';
+					doit = 1;
+				} else {
+					dirc = ' ';
+					if (s_name[0] != 0) {
+						files++;
+						doit = 1;
+					}
+				}
+
+				if (doit) {
+					if (dirc == ' ') {
+						printf(" %8ld   %s%c\n",
+							(long)FAT2CPU32(dentptr->size),
+							s_name, dirc);
+					} else {
+						printf("            %s%c\n",
+							s_name, dirc);
+					}
+				}
+
+				dentptr++;
+				continue;
+			}
+
+			if (strcmp(filename, s_name)
+			    && strcmp(filename, l_name)) {
+				debug("Mismatch: |%s|%s|\n", s_name, l_name);
+				dentptr++;
+				continue;
+			}
+
+			memcpy(retdent, dentptr, sizeof(dir_entry));
+
+			debug("DentName: %s", s_name);
+			debug(", start: 0x%x", START(dentptr));
+			debug(", size:  0x%x %s\n",
+			      FAT2CPU32(dentptr->size),
+			      (dentptr->attr & ATTR_DIR) ? "(DIR)" : "");
+
+			return retdent;
 		}
-		if (doit) {
-		    if (dirc == ' ') {
-			printf (" %8ld   %s%c\n",
-				(long) FAT2CPU32 (dentptr->size), s_name,
-				dirc);
-		    } else {
-			printf ("            %s%c\n", s_name, dirc);
-		    }
+
+		curclust = get_fatent(mydata, curclust);
+		if (CHECK_CLUST(curclust, mydata->fatsize)) {
+			debug("curclust: 0x%x\n", curclust);
+			printf("Invalid FAT entry\n");
+			return NULL;
 		}
-		dentptr++;
-		continue;
-	    }
-	    if (strcmp (filename, s_name) && strcmp (filename, l_name)) {
-		FAT_DPRINT ("Mismatch: |%s|%s|\n", s_name, l_name);
-		dentptr++;
-		continue;
-	    }
-	    memcpy (retdent, dentptr, sizeof (dir_entry));
-
-	    FAT_DPRINT ("DentName: %s", s_name);
-	    FAT_DPRINT (", start: 0x%x", START (dentptr));
-	    FAT_DPRINT (", size:  0x%x %s\n",
-			FAT2CPU32 (dentptr->size),
-			(dentptr->attr & ATTR_DIR) ? "(DIR)" : "");
-
-	    return retdent;
 	}
-	curclust = get_fatent (mydata, curclust);
-	if (CHECK_CLUST(curclust, mydata->fatsize)) {
-	    FAT_DPRINT ("curclust: 0x%x\n", curclust);
-	    FAT_ERROR ("Invalid FAT entry\n");
-	    return NULL;
-	}
-    }
 
-    return NULL;
+	return NULL;
 }
-
 
 /*
  * Read boot sector and volume info from a FAT filesystem
  */
 static int
-read_bootsectandvi(boot_sector *bs, volume_info *volinfo, int *fatsize)
+read_bootsectandvi (boot_sector *bs, volume_info *volinfo, int *fatsize)
 {
 	__u8 block[FS_BLOCK_SIZE];
+
 	volume_info *vistart;
 	char *fstype;
 
-	if (disk_read(0, 1, block) < 0) {
-		FAT_DPRINT("Error: reading block\n");
+	if (disk_read (0, 1, block) < 0) {
+		debug("Error: reading block\n");
 		return -1;
 	}
 
 	memcpy(bs, block, sizeof(boot_sector));
-	bs->reserved	= FAT2CPU16(bs->reserved);
-	bs->fat_length	= FAT2CPU16(bs->fat_length);
-	bs->secs_track	= FAT2CPU16(bs->secs_track);
-	bs->heads	= FAT2CPU16(bs->heads);
-#if 0 /* UNUSED */
-	bs->hidden	= FAT2CPU32(bs->hidden);
-#endif
-	bs->total_sect	= FAT2CPU32(bs->total_sect);
+	bs->reserved = FAT2CPU16(bs->reserved);
+	bs->fat_length = FAT2CPU16(bs->fat_length);
+	bs->secs_track = FAT2CPU16(bs->secs_track);
+	bs->heads = FAT2CPU16(bs->heads);
+	bs->total_sect = FAT2CPU32(bs->total_sect);
 
 	/* FAT32 entries */
 	if (bs->fat_length == 0) {
 		/* Assume FAT32 */
 		bs->fat32_length = FAT2CPU32(bs->fat32_length);
-		bs->flags	 = FAT2CPU16(bs->flags);
+		bs->flags = FAT2CPU16(bs->flags);
 		bs->root_cluster = FAT2CPU32(bs->root_cluster);
-		bs->info_sector  = FAT2CPU16(bs->info_sector);
-		bs->backup_boot  = FAT2CPU16(bs->backup_boot);
-		vistart = (volume_info*) (block + sizeof(boot_sector));
+		bs->info_sector = FAT2CPU16(bs->info_sector);
+		bs->backup_boot = FAT2CPU16(bs->backup_boot);
+		vistart = (volume_info *)(block + sizeof(boot_sector));
 		*fatsize = 32;
 	} else {
-		vistart = (volume_info*) &(bs->fat32_length);
+		vistart = (volume_info *)&(bs->fat32_length);
 		*fatsize = 0;
 	}
 	memcpy(volinfo, vistart, sizeof(volume_info));
@@ -1042,9 +1073,8 @@ read_bootsectandvi(boot_sector *bs, volume_info *volinfo, int *fatsize)
 	fstype[8] = '\0';
 
 	if (*fatsize == 32) {
-		if (compare_sign(FAT32_SIGN, vistart->fs_type) == 0) {
+		if (compare_sign(FAT32_SIGN, vistart->fs_type) == 0)
 			return 0;
-		}
 	} else {
 		if (compare_sign(FAT12_SIGN, vistart->fs_type) == 0) {
 			*fatsize = 12;
@@ -1056,352 +1086,404 @@ read_bootsectandvi(boot_sector *bs, volume_info *volinfo, int *fatsize)
 		}
 	}
 
-	FAT_DPRINT("Error: broken fs_type sign\n");
+	debug("Error: broken fs_type sign\n");
 	return -1;
 }
 
-__attribute__ ((__aligned__(__alignof__(dir_entry))))
+__attribute__ ((__aligned__ (__alignof__ (dir_entry))))
 __u8 do_fat_read_block[MAX_CLUSTSIZE];
+
 long
 do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 	     int dols)
 {
 #if CONFIG_NIOS /* NIOS CPU cannot access big automatic arrays */
-    static
+	static
 #endif
-    char fnamecopy[2048];
-    boot_sector bs;
-    volume_info volinfo;
-    fsdata datablock;
-    fsdata *mydata = &datablock;
-    dir_entry *dentptr;
-    __u16 prevcksum = 0xffff;
-    char *subname = "";
-    int cursect;
-    int idx, isdir = 0;
-    int files = 0, dirs = 0;
-    long ret = 0;
-    int firsttime;
-    int root_cluster;
-    int j;
+	char fnamecopy[2048];
+	boot_sector bs;
+	volume_info volinfo;
+	fsdata datablock;
+	fsdata *mydata = &datablock;
+	dir_entry *dentptr;
+	__u16 prevcksum = 0xffff;
+	char *subname = "";
+	int cursect;
+	int idx, isdir = 0;
+	int files = 0, dirs = 0;
+	long ret = 0;
+	int firsttime;
+	int root_cluster;
+	int j;
 
-    if (read_bootsectandvi (&bs, &volinfo, &mydata->fatsize)) {
-	FAT_DPRINT ("Error: reading boot sector\n");
-	return -1;
-    }
+	if (read_bootsectandvi(&bs, &volinfo, &mydata->fatsize)) {
+		debug("Error: reading boot sector\n");
+		return -1;
+	}
+
 	root_cluster = bs.root_cluster;
-    if (mydata->fatsize == 32) {
-	mydata->fatlength = bs.fat32_length;
-    } else {
-	mydata->fatlength = bs.fat_length;
-    }
-    mydata->fat_sect = bs.reserved;
-    cursect = mydata->rootdir_sect
-	    = mydata->fat_sect + mydata->fatlength * bs.fats;
-    mydata->clust_size = bs.cluster_size;
-    if (mydata->fatsize == 32) {
-	mydata->data_begin = mydata->rootdir_sect
-		- (mydata->clust_size * 2);
-    } else {
-	int rootdir_size;
 
-	rootdir_size = ((bs.dir_entries[1] * (int) 256 + bs.dir_entries[0])
-			* sizeof (dir_entry)) / SECTOR_SIZE;
-	mydata->data_begin = mydata->rootdir_sect + rootdir_size
-		- (mydata->clust_size * 2);
-    }
-    mydata->fatbufnum = -1;
+	if (mydata->fatsize == 32)
+		mydata->fatlength = bs.fat32_length;
+	else
+		mydata->fatlength = bs.fat_length;
 
-#ifdef CONFIG_SUPPORT_VFAT
-    FAT_DPRINT ("VFAT Support enabled\n");
-#endif
-    FAT_DPRINT ("FAT%d, fat_sect: %d, fatlength: %d\n",
-		mydata->fatsize,
-		mydata->fat_sect,
-		mydata->fatlength);
-    FAT_DPRINT ("Rootdir begins at cluster: %d, sector: %d, offset: %x\n"
-		"Data begins at: %d\n",
-		root_cluster,
-		mydata->rootdir_sect,
-		mydata->rootdir_sect * SECTOR_SIZE,
-		mydata->data_begin);
-    FAT_DPRINT ("Cluster size: %d\n", mydata->clust_size);
+	mydata->fat_sect = bs.reserved;
 
-    /* "cwd" is always the root... */
-    while (ISDIRDELIM (*filename))
-	filename++;
-    /* Make a copy of the filename and convert it to lowercase */
-    strcpy (fnamecopy, filename);
-    downcase (fnamecopy);
-    if (*fnamecopy == '\0') {
-	if (!dols)
-	    return -1;
-	dols = LS_ROOT;
-    } else if ((idx = dirdelim (fnamecopy)) >= 0) {
-	isdir = 1;
-	fnamecopy[idx] = '\0';
-	subname = fnamecopy + idx + 1;
-	/* Handle multiple delimiters */
-	while (ISDIRDELIM (*subname))
-	    subname++;
-    } else if (dols) {
-	isdir = 1;
-    }
+	cursect = mydata->rootdir_sect
+		= mydata->fat_sect + mydata->fatlength * bs.fats;
 
-    j=0;
-    while (1) {
-	int i;
+	mydata->clust_size = bs.cluster_size;
 
-	FAT_DPRINT ("FAT read sect=%d, clust_size=%d, DIRENTSPERBLOCK=%d\n",
-		cursect, mydata->clust_size, DIRENTSPERBLOCK);
-	if (disk_read (cursect, mydata->clust_size, do_fat_read_block) < 0) {
-	    FAT_DPRINT ("Error: reading rootdir block\n");
-	    return -1;
+	if (mydata->fatsize == 32) {
+		mydata->data_begin = mydata->rootdir_sect -
+					(mydata->clust_size * 2);
+	} else {
+		int rootdir_size;
+
+		rootdir_size = ((bs.dir_entries[1]  * (int)256 +
+				 bs.dir_entries[0]) *
+				 sizeof(dir_entry)) /
+				 SECTOR_SIZE;
+		mydata->data_begin = mydata->rootdir_sect +
+					rootdir_size -
+					(mydata->clust_size * 2);
 	}
-	dentptr = (dir_entry *) do_fat_read_block;
-	for (i = 0; i < DIRENTSPERBLOCK; i++) {
-	    char s_name[14], l_name[256];
 
-	    l_name[0] = '\0';
-	    if ((dentptr->attr & ATTR_VOLUME)) {
+	mydata->fatbufnum = -1;
+
 #ifdef CONFIG_SUPPORT_VFAT
-		if (((dentptr->attr & ATTR_VFAT) == ATTR_VFAT) &&
-		    (dentptr->name[0] & LAST_LONG_ENTRY_MASK)) {
-		    prevcksum = ((dir_slot *) dentptr)->alias_checksum;
-		    get_vfatname (mydata, 0, do_fat_read_block, dentptr, l_name);
-		    if (dols == LS_ROOT) {
-			int isdir = (dentptr->attr & ATTR_DIR);
-			char dirc;
-			int doit = 0;
-
-			if (isdir) {
-			    dirs++;
-			    dirc = '/';
-			    doit = 1;
-			} else {
-			    dirc = ' ';
-			    if (l_name[0] != 0) {
-				files++;
-				doit = 1;
-			    }
-			}
-			if (doit) {
-			    if (dirc == ' ') {
-				printf (" %8ld   %s%c\n",
-					(long) FAT2CPU32 (dentptr->size),
-					l_name, dirc);
-			    } else {
-				printf ("            %s%c\n", l_name, dirc);
-			    }
-			}
-			dentptr++;
-			continue;
-		    }
-		    FAT_DPRINT ("Rootvfatname: |%s|\n", l_name);
-		} else
+	debug("VFAT Support enabled\n");
 #endif
-		{
-		    /* Volume label or VFAT entry */
-		    dentptr++;
-		    continue;
+	debug("FAT%d, fat_sect: %d, fatlength: %d\n",
+	       mydata->fatsize, mydata->fat_sect, mydata->fatlength);
+	debug("Rootdir begins at cluster: %d, sector: %d, offset: %x\n"
+	       "Data begins at: %d\n",
+	       root_cluster,
+	       mydata->rootdir_sect,
+	       mydata->rootdir_sect * SECTOR_SIZE, mydata->data_begin);
+	debug("Cluster size: %d\n", mydata->clust_size);
+
+	/* "cwd" is always the root... */
+	while (ISDIRDELIM(*filename))
+		filename++;
+
+	/* Make a copy of the filename and convert it to lowercase */
+	strcpy(fnamecopy, filename);
+	downcase(fnamecopy);
+
+	if (*fnamecopy == '\0') {
+		if (!dols)
+			return -1;
+
+		dols = LS_ROOT;
+	} else if ((idx = dirdelim(fnamecopy)) >= 0) {
+		isdir = 1;
+		fnamecopy[idx] = '\0';
+		subname = fnamecopy + idx + 1;
+
+		/* Handle multiple delimiters */
+		while (ISDIRDELIM(*subname))
+			subname++;
+	} else if (dols) {
+		isdir = 1;
+	}
+
+	j = 0;
+	while (1) {
+		int i;
+
+		debug("FAT read sect=%d, clust_size=%d, DIRENTSPERBLOCK=%d\n",
+			cursect, mydata->clust_size, DIRENTSPERBLOCK);
+
+		if (disk_read(cursect, mydata->clust_size, do_fat_read_block) < 0) {
+			debug("Error: reading rootdir block\n");
+			return -1;
 		}
-	    } else if (dentptr->name[0] == 0) {
-		FAT_DPRINT ("RootDentname == NULL - %d\n", i);
-		if (dols == LS_ROOT) {
-		    printf ("\n%d file(s), %d dir(s)\n\n", files, dirs);
-		    return 0;
-		}
-		return -1;
-	    }
+
+		dentptr = (dir_entry *) do_fat_read_block;
+
+		for (i = 0; i < DIRENTSPERBLOCK; i++) {
+			char s_name[14], l_name[256];
+
+			l_name[0] = '\0';
+			if ((dentptr->attr & ATTR_VOLUME)) {
 #ifdef CONFIG_SUPPORT_VFAT
-	    else if (dols == LS_ROOT
-		     && mkcksum (dentptr->name) == prevcksum) {
-		dentptr++;
-		continue;
-	    }
-#endif
-	    get_name (dentptr, s_name);
-	    if (dols == LS_ROOT) {
-		int isdir = (dentptr->attr & ATTR_DIR);
-		char dirc;
-		int doit = 0;
+				if ((dentptr->attr & ATTR_VFAT) == ATTR_VFAT &&
+				    (dentptr->name[0] & LAST_LONG_ENTRY_MASK)) {
+					prevcksum =
+						((dir_slot *)dentptr)->alias_checksum;
 
-		if (isdir) {
-		    dirc = '/';
-		    if (s_name[0] != 0) {
-			dirs++;
-			doit = 1;
-		    }
+					get_vfatname(mydata, 0,
+						     do_fat_read_block,
+						     dentptr, l_name);
+
+					if (dols == LS_ROOT) {
+						char dirc;
+						int doit = 0;
+						int isdir =
+							(dentptr->attr & ATTR_DIR);
+
+						if (isdir) {
+							dirs++;
+							dirc = '/';
+							doit = 1;
+						} else {
+							dirc = ' ';
+							if (l_name[0] != 0) {
+								files++;
+								doit = 1;
+							}
+						}
+						if (doit) {
+							if (dirc == ' ') {
+								printf(" %8ld   %s%c\n",
+									(long)FAT2CPU32(dentptr->size),
+									l_name,
+									dirc);
+							} else {
+								printf("            %s%c\n",
+									l_name,
+									dirc);
+							}
+						}
+						dentptr++;
+						continue;
+					}
+					debug("Rootvfatname: |%s|\n",
+					       l_name);
+				} else
+#endif
+				{
+					/* Volume label or VFAT entry */
+					dentptr++;
+					continue;
+				}
+			} else if (dentptr->name[0] == 0) {
+				debug("RootDentname == NULL - %d\n", i);
+				if (dols == LS_ROOT) {
+					printf("\n%d file(s), %d dir(s)\n\n",
+						files, dirs);
+					return 0;
+				}
+				return -1;
+			}
+#ifdef CONFIG_SUPPORT_VFAT
+			else if (dols == LS_ROOT &&
+				 mkcksum(dentptr->name) == prevcksum) {
+				dentptr++;
+				continue;
+			}
+#endif
+			get_name(dentptr, s_name);
+
+			if (dols == LS_ROOT) {
+				int isdir = (dentptr->attr & ATTR_DIR);
+				char dirc;
+				int doit = 0;
+
+				if (isdir) {
+					dirc = '/';
+					if (s_name[0] != 0) {
+						dirs++;
+						doit = 1;
+					}
+				} else {
+					dirc = ' ';
+					if (s_name[0] != 0) {
+						files++;
+						doit = 1;
+					}
+				}
+				if (doit) {
+					if (dirc == ' ') {
+						printf(" %8ld   %s%c\n",
+							(long)FAT2CPU32(dentptr->size),
+							s_name, dirc);
+					} else {
+						printf("            %s%c\n",
+							s_name, dirc);
+					}
+				}
+				dentptr++;
+				continue;
+			}
+
+			if (strcmp(fnamecopy, s_name)
+			    && strcmp(fnamecopy, l_name)) {
+				debug("RootMismatch: |%s|%s|\n", s_name,
+				       l_name);
+				dentptr++;
+				continue;
+			}
+
+			if (isdir && !(dentptr->attr & ATTR_DIR))
+				return -1;
+
+			debug("RootName: %s", s_name);
+			debug(", start: 0x%x", START(dentptr));
+			debug(", size:  0x%x %s\n",
+			       FAT2CPU32(dentptr->size),
+			       isdir ? "(DIR)" : "");
+
+			goto rootdir_done;	/* We got a match */
+		}
+		debug("END LOOP: j=%d   clust_size=%d\n", j,
+		       mydata->clust_size);
+
+		/*
+		 * On FAT32 we must fetch the FAT entries for the next
+		 * root directory clusters when a cluster has been
+		 * completely processed.
+		 */
+		if ((mydata->fatsize == 32) && (++j == mydata->clust_size)) {
+			int nxtsect;
+			int nxt_clust;
+
+			nxt_clust = get_fatent(mydata, root_cluster);
+
+			nxtsect = mydata->data_begin +
+				(nxt_clust * mydata->clust_size);
+
+			debug("END LOOP: sect=%d, root_clust=%d, "
+			      "n_sect=%d, n_clust=%d\n",
+			      cursect, root_cluster,
+			      nxtsect, nxt_clust);
+
+			root_cluster = nxt_clust;
+
+			cursect = nxtsect;
+			j = 0;
 		} else {
-		    dirc = ' ';
-		    if (s_name[0] != 0) {
-			files++;
-			doit = 1;
-		    }
+			cursect++;
 		}
-		if (doit) {
-		    if (dirc == ' ') {
-			printf (" %8ld   %s%c\n",
-				(long) FAT2CPU32 (dentptr->size), s_name,
-				dirc);
-		    } else {
-			printf ("            %s%c\n", s_name, dirc);
-		    }
+	}
+rootdir_done:
+
+	firsttime = 1;
+
+	while (isdir) {
+		int startsect = mydata->data_begin
+			+ START(dentptr) * mydata->clust_size;
+		dir_entry dent;
+		char *nextname = NULL;
+
+		dent = *dentptr;
+		dentptr = &dent;
+
+		idx = dirdelim(subname);
+
+		if (idx >= 0) {
+			subname[idx] = '\0';
+			nextname = subname + idx + 1;
+			/* Handle multiple delimiters */
+			while (ISDIRDELIM(*nextname))
+				nextname++;
+			if (dols && *nextname == '\0')
+				firsttime = 0;
+		} else {
+			if (dols && firsttime) {
+				firsttime = 0;
+			} else {
+				isdir = 0;
+			}
 		}
-		dentptr++;
-		continue;
-	    }
-	    if (strcmp (fnamecopy, s_name) && strcmp (fnamecopy, l_name)) {
-		FAT_DPRINT ("RootMismatch: |%s|%s|\n", s_name, l_name);
-		dentptr++;
-		continue;
-	    }
-	    if (isdir && !(dentptr->attr & ATTR_DIR))
-		return -1;
 
-	    FAT_DPRINT ("RootName: %s", s_name);
-	    FAT_DPRINT (", start: 0x%x", START (dentptr));
-	    FAT_DPRINT (", size:  0x%x %s\n",
-			FAT2CPU32 (dentptr->size), isdir ? "(DIR)" : "");
+		if (get_dentfromdir(mydata, startsect, subname, dentptr,
+				     isdir ? 0 : dols) == NULL) {
+			if (dols && !isdir)
+				return 0;
+			return -1;
+		}
 
-	    goto rootdir_done;  /* We got a match */
+		if (idx >= 0) {
+			if (!(dentptr->attr & ATTR_DIR))
+				return -1;
+			subname = nextname;
+		}
 	}
-	FAT_DPRINT ("END LOOP: j=%d   clust_size=%d\n", j, mydata->clust_size);
-
-	/*
-	 * On FAT32 we must fetch the FAT entries for the next
-	 * root directory clusters when a cluster has been
-	 * completely processed.
-	 */
-	if ((mydata->fatsize == 32) && (++j == mydata->clust_size)) {
-		int nxtsect;
-		int cur_clust, nxt_clust;
-
-		cur_clust = (cursect - mydata->data_begin) / mydata->clust_size;
-		nxt_clust = get_fatent(mydata, root_cluster);
-		nxtsect = mydata->data_begin + (nxt_clust * mydata->clust_size);
-		FAT_DPRINT ("END LOOP: sect=%d, clust=%d, root_clust=%d, n_sect=%d, n_clust=%d\n",
-			cursect, cur_clust, root_cluster, nxtsect, nxt_clust);
-		root_cluster = nxt_clust;
-
-		cursect = nxtsect;
-		j = 0;
-	} else {
-		cursect++;
-	}
-    }
-  rootdir_done:
-
-    firsttime = 1;
-    while (isdir) {
-	int startsect = mydata->data_begin
-		+ START (dentptr) * mydata->clust_size;
-	dir_entry dent;
-	char *nextname = NULL;
-
-	dent = *dentptr;
-	dentptr = &dent;
-
-	idx = dirdelim (subname);
-	if (idx >= 0) {
-	    subname[idx] = '\0';
-	    nextname = subname + idx + 1;
-	    /* Handle multiple delimiters */
-	    while (ISDIRDELIM (*nextname))
-		nextname++;
-	    if (dols && *nextname == '\0')
-		firsttime = 0;
-	} else {
-	    if (dols && firsttime) {
-		firsttime = 0;
-	    } else {
-		isdir = 0;
-	    }
-	}
-
-	if (get_dentfromdir (mydata, startsect, subname, dentptr,
-			     isdir ? 0 : dols) == NULL) {
-	    if (dols && !isdir)
-		return 0;
-	    return -1;
-	}
-
-	if (idx >= 0) {
-	    if (!(dentptr->attr & ATTR_DIR))
-		return -1;
-	    subname = nextname;
-	}
-    }
-    if(buffer)
-    {
-        ret = get_contents (mydata, dentptr, buffer, maxsize);
+	if(buffer) {
+		ret = get_contents(mydata, dentptr, buffer, maxsize);
 		flush_cache((unsigned long)buffer, FAT2CPU32(dentptr->size));
-        FAT_DPRINT ("Size: %d, got: %ld\n", FAT2CPU32 (dentptr->size), ret);
-    }
-    else
-    {
-        //for comand fatexist
-        ret = FAT2CPU32(dentptr->size);
-    }
+		debug("Size: %d, got: %ld\n", FAT2CPU32 (dentptr->size), ret);
+	} else {
+		//for comand fatexist
+		ret = FAT2CPU32(dentptr->size);
+	}
 
-    return ret;
+	return ret;
 }
 
-
-int
-file_fat_detectfs(void)
+int file_fat_detectfs (void)
 {
-	boot_sector	bs;
-	volume_info	volinfo;
-	int		fatsize;
-	char	vol_label[12];
+	boot_sector bs;
+	volume_info volinfo;
+	int fatsize;
+	char vol_label[12];
 
-	if(cur_dev==NULL) {
+	if (cur_dev == NULL) {
 		printf("No current device\n");
 		return 1;
 	}
+
 #if defined(CONFIG_CMD_IDE) || \
     defined(CONFIG_CMD_SATA) || \
     defined(CONFIG_CMD_SCSI) || \
     defined(CONFIG_CMD_USB) || \
     defined(CONFIG_MMC)
 	printf("Interface:  ");
-	switch(cur_dev->if_type) {
-		case IF_TYPE_IDE :	printf("IDE"); break;
-		case IF_TYPE_SATA :	printf("SATA"); break;
-		case IF_TYPE_SCSI :	printf("SCSI"); break;
-		case IF_TYPE_ATAPI :	printf("ATAPI"); break;
-		case IF_TYPE_USB :	printf("USB"); break;
-		case IF_TYPE_DOC :	printf("DOC"); break;
-		case IF_TYPE_MMC :	printf("MMC"); break;
-		default :		printf("Unknown");
+	switch (cur_dev->if_type) {
+	case IF_TYPE_IDE:
+		printf("IDE");
+		break;
+	case IF_TYPE_SATA:
+		printf("SATA");
+		break;
+	case IF_TYPE_SCSI:
+		printf("SCSI");
+		break;
+	case IF_TYPE_ATAPI:
+		printf("ATAPI");
+		break;
+	case IF_TYPE_USB:
+		printf("USB");
+		break;
+	case IF_TYPE_DOC:
+		printf("DOC");
+		break;
+	case IF_TYPE_MMC:
+		printf("MMC");
+		break;
+	default:
+		printf("Unknown");
 	}
-	printf("\n  Device %d: ",cur_dev->dev);
+
+	printf("\n  Device %d: ", cur_dev->dev);
 	dev_print(cur_dev);
 #endif
-	if(read_bootsectandvi(&bs, &volinfo, &fatsize)) {
+
+	if (read_bootsectandvi(&bs, &volinfo, &fatsize)) {
 		printf("\nNo valid FAT fs found\n");
 		return 1;
 	}
-	memcpy (vol_label, volinfo.volume_label, 11);
+
+	memcpy(vol_label, volinfo.volume_label, 11);
 	vol_label[11] = '\0';
-	volinfo.fs_type[5]='\0';
-	printf("Partition %d: Filesystem: %s \"%s\"\n"
-			,cur_part,volinfo.fs_type,vol_label);
+	volinfo.fs_type[5] = '\0';
+
+	printf("Partition %d: Filesystem: %s \"%s\"\n", cur_part,
+		volinfo.fs_type, vol_label);
+
 	return 0;
 }
 
-
-int
-file_fat_ls(const char *dir)
+int file_fat_ls (const char *dir)
 {
 	return do_fat_read(dir, NULL, 0, LS_YES);
 }
 
-
-long
-file_fat_read(const char *filename, void *buffer, unsigned long maxsize)
+long file_fat_read (const char *filename, void *buffer, unsigned long maxsize)
 {
-	printf("reading %s\n",filename);
+	printf("reading %s\n", filename);
 	return do_fat_read(filename, buffer, maxsize, LS_NO);
 }

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -544,6 +544,9 @@ get_fatent(fsdata *mydata, __u32 entry)
 		return ret;
 	}
 
+	FAT_DPRINT("FAT%d: entry: 0x%04x = %d, offset: 0x%04x = %d\n",
+		mydata->fatsize, entry, entry, offset, offset);
+
 	/* Read a new block of FAT entries into the cache. */
 	if (bufnum != mydata->fatbufnum) {
 		int getsize = FATBUFSIZE/FS_BLOCK_SIZE;
@@ -603,7 +606,8 @@ get_fatent(fsdata *mydata, __u32 entry)
 	}
 	break;
 	}
-	FAT_DPRINT("ret: %d, offset: %d\n", ret, offset);
+	FAT_DPRINT("FAT%d: ret: %08x, offset: %04x\n",
+		mydata->fatsize, ret, offset);
 
 	return ret;
 }
@@ -666,7 +670,7 @@ get_contents(fsdata *mydata, dir_entry *dentptr, __u8 *buffer,
 
 	if (maxsize > 0 && filesize > maxsize) filesize = maxsize;
 
-	FAT_DPRINT("Reading: %ld bytes\n", filesize);
+	FAT_DPRINT("%ld bytes\n", filesize);
 
 	actsize=bytesperclust;
 	endclust=curclust;
@@ -1073,16 +1077,19 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
     dir_entry *dentptr;
     __u16 prevcksum = 0xffff;
     char *subname = "";
-    int rootdir_size, cursect;
+    int cursect;
     int idx, isdir = 0;
     int files = 0, dirs = 0;
     long ret = 0;
     int firsttime;
+    int root_cluster;
+    int j;
 
     if (read_bootsectandvi (&bs, &volinfo, &mydata->fatsize)) {
 	FAT_DPRINT ("Error: reading boot sector\n");
 	return -1;
     }
+	root_cluster = bs.root_cluster;
     if (mydata->fatsize == 32) {
 	mydata->fatlength = bs.fat32_length;
     } else {
@@ -1093,10 +1100,11 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 	    = mydata->fat_sect + mydata->fatlength * bs.fats;
     mydata->clust_size = bs.cluster_size;
     if (mydata->fatsize == 32) {
-	rootdir_size = mydata->clust_size;
-	mydata->data_begin = mydata->rootdir_sect   /* + rootdir_size */
+	mydata->data_begin = mydata->rootdir_sect
 		- (mydata->clust_size * 2);
     } else {
+	int rootdir_size;
+
 	rootdir_size = ((bs.dir_entries[1] * (int) 256 + bs.dir_entries[0])
 			* sizeof (dir_entry)) / SECTOR_SIZE;
 	mydata->data_begin = mydata->rootdir_sect + rootdir_size
@@ -1104,12 +1112,19 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
     }
     mydata->fatbufnum = -1;
 
-    FAT_DPRINT ("FAT%d, fatlength: %d\n", mydata->fatsize,
+#ifdef CONFIG_SUPPORT_VFAT
+    FAT_DPRINT ("VFAT Support enabled\n");
+#endif
+    FAT_DPRINT ("FAT%d, fat_sect: %d, fatlength: %d\n",
+		mydata->fatsize,
+		mydata->fat_sect,
 		mydata->fatlength);
-    FAT_DPRINT ("Rootdir begins at sector: %d, offset: %x, size: %d\n"
+    FAT_DPRINT ("Rootdir begins at cluster: %d, sector: %d, offset: %x\n"
 		"Data begins at: %d\n",
-		mydata->rootdir_sect, mydata->rootdir_sect * SECTOR_SIZE,
-		rootdir_size, mydata->data_begin);
+		root_cluster,
+		mydata->rootdir_sect,
+		mydata->rootdir_sect * SECTOR_SIZE,
+		mydata->data_begin);
     FAT_DPRINT ("Cluster size: %d\n", mydata->clust_size);
 
     /* "cwd" is always the root... */
@@ -1133,9 +1148,12 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 	isdir = 1;
     }
 
+    j=0;
     while (1) {
 	int i;
 
+	FAT_DPRINT ("FAT read sect=%d, clust_size=%d, DIRENTSPERBLOCK=%d\n",
+		cursect, mydata->clust_size, DIRENTSPERBLOCK);
 	if (disk_read (cursect, mydata->clust_size, do_fat_read_block) < 0) {
 	    FAT_DPRINT ("Error: reading rootdir block\n");
 	    return -1;
@@ -1248,7 +1266,29 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 
 	    goto rootdir_done;  /* We got a match */
 	}
-	cursect++;
+	FAT_DPRINT ("END LOOP: j=%d   clust_size=%d\n", j, mydata->clust_size);
+
+	/*
+	 * On FAT32 we must fetch the FAT entries for the next
+	 * root directory clusters when a cluster has been
+	 * completely processed.
+	 */
+	if ((mydata->fatsize == 32) && (++j == mydata->clust_size)) {
+		int nxtsect;
+		int cur_clust, nxt_clust;
+
+		cur_clust = (cursect - mydata->data_begin) / mydata->clust_size;
+		nxt_clust = get_fatent(mydata, root_cluster);
+		nxtsect = mydata->data_begin + (nxt_clust * mydata->clust_size);
+		FAT_DPRINT ("END LOOP: sect=%d, clust=%d, root_clust=%d, n_sect=%d, n_clust=%d\n",
+			cursect, cur_clust, root_cluster, nxtsect, nxt_clust);
+		root_cluster = nxt_clust;
+
+		cursect = nxtsect;
+		j = 0;
+	} else {
+		cursect++;
+	}
     }
   rootdir_done:
 

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -784,10 +784,9 @@ get_vfatname (fsdata *mydata, int curclust, __u8 *cluster,
 {
 	dir_entry *realdent;
 	dir_slot *slotptr = (dir_slot *)retdent;
-	__u8 *buflimit = cluster + ((curclust == 0) ?
-					LINEAR_PREFETCH_SIZE :
-					(mydata->clust_size * mydata->sect_size)
-				   );
+	__u8 *buflimit = cluster + mydata->sect_size * ((curclust == 0) ?
+							PREFETCH_BLOCKS :
+							mydata->clust_size);
 	__u8 counter = (slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff;
 	int idx = 0;
 
@@ -1235,7 +1234,7 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 		if (disk_read(cursect,
 				(mydata->fatsize == 32) ?
 				(mydata->clust_size) :
-				LINEAR_PREFETCH_SIZE / mydata->sect_size,
+				PREFETCH_BLOCKS,
 				do_fat_read_block) < 0) {
 			debug("Error: reading rootdir block\n");
 			goto exit;

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -553,7 +553,7 @@ static __u32 get_fatent (fsdata *mydata, __u32 entry)
 
 	/* Read a new block of FAT entries into the cache. */
 	if (bufnum != mydata->fatbufnum) {
-		int getsize = FATBUFSIZE / FS_BLOCK_SIZE;
+		__u32 getsize = FATBUFSIZE / FS_BLOCK_SIZE;
 		__u8 *bufptr = mydata->fatbuf;
 		__u32 fatlength = mydata->fatlength;
 		__u32 startblock = bufnum * FATBUFBLOCKS;
@@ -623,7 +623,7 @@ static int
 get_cluster (fsdata *mydata, __u32 clustnum, __u8 *buffer,
 	     unsigned long size)
 {
-	int idx = 0;
+	__u32 idx = 0;
 	__u32 startsect;
 
 	if (clustnum > 0) {
@@ -1122,12 +1122,13 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 	dir_entry *dentptr;
 	__u16 prevcksum = 0xffff;
 	char *subname = "";
-	int cursect;
+	__u32 cursect;
 	int idx, isdir = 0;
 	int files = 0, dirs = 0;
 	long ret = 0;
 	int firsttime;
-	int root_cluster;
+	__u32 root_cluster;
+	int rootdir_size = 0;
 	int j;
 
 	if (read_bootsectandvi(&bs, &volinfo, &mydata->fatsize)) {
@@ -1153,8 +1154,6 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 		mydata->data_begin = mydata->rootdir_sect -
 					(mydata->clust_size * 2);
 	} else {
-		int rootdir_size;
-
 		rootdir_size = ((bs.dir_entries[1]  * (int)256 +
 				 bs.dir_entries[0]) *
 				 sizeof(dir_entry)) /
@@ -1361,19 +1360,17 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 		 * root directory clusters when a cluster has been
 		 * completely processed.
 		 */
-		if ((mydata->fatsize == 32) && (++j == mydata->clust_size)) {
-			int nxtsect;
-			int nxt_clust;
+		++j;
+		int fat32_end = 0;
+		if ((mydata->fatsize == 32) && (j == mydata->clust_size)) {
+			int nxtsect = 0;
+			int nxt_clust = 0;
 
 			nxt_clust = get_fatent(mydata, root_cluster);
+			fat32_end = CHECK_CLUST(nxt_clust, 32);
 
 			nxtsect = mydata->data_begin +
 				(nxt_clust * mydata->clust_size);
-
-			debug("END LOOP: sect=%d, root_clust=%d, "
-			      "n_sect=%d, n_clust=%d\n",
-			      cursect, root_cluster,
-			      nxtsect, nxt_clust);
 
 			root_cluster = nxt_clust;
 
@@ -1381,6 +1378,18 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 			j = 0;
 		} else {
 			cursect++;
+		}
+
+		/* If end of rootdir reached */
+		if ((mydata->fatsize == 32 && fat32_end) ||
+		    (mydata->fatsize != 32 && j == rootdir_size)) {
+			if (dols == LS_ROOT) {
+				printf("\n%d file(s), %d dir(s)\n\n",
+				       files, dirs);
+				return 0;
+			} else {
+				return -1;
+			}
 		}
 	}
 rootdir_done:

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -553,16 +553,17 @@ static __u32 get_fatent (fsdata *mydata, __u32 entry)
 
 	/* Read a new block of FAT entries into the cache. */
 	if (bufnum != mydata->fatbufnum) {
-		__u32 getsize = FATBUFSIZE / mydata->sect_size;
+		__u32 getsize = FATBUFBLOCKS;
 		__u8 *bufptr = mydata->fatbuf;
 		__u32 fatlength = mydata->fatlength;
 		__u32 startblock = bufnum * FATBUFBLOCKS;
 
+		if (getsize > fatlength)
+			getsize = fatlength;
+
 		fatlength *= mydata->sect_size;	/* We want it in bytes now */
 		startblock += mydata->fat_sect;	/* Offset from start of disk */
 
-		if (getsize > fatlength)
-			getsize = fatlength;
 		if (disk_read(startblock, getsize, bufptr) < 0) {
 			debug("Error reading FAT blocks\n");
 			return ret;

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -783,11 +783,19 @@ get_vfatname (fsdata *mydata, int curclust, __u8 *cluster,
 {
 	dir_entry *realdent;
 	dir_slot *slotptr = (dir_slot *)retdent;
-	__u8 *nextclust = cluster + mydata->clust_size * SECTOR_SIZE;
+	__u8 *buflimit = cluster + ((curclust == 0) ?
+					LINEAR_PREFETCH_SIZE :
+					(mydata->clust_size * SECTOR_SIZE)
+				   );
 	__u8 counter = (slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff;
 	int idx = 0;
 
-	while ((__u8 *)slotptr < nextclust) {
+	if (counter > VFAT_MAXSEQ) {
+		debug("Error: VFAT name is too long\n");
+		return -1;
+	}
+
+	while ((__u8 *)slotptr < buflimit) {
 		if (counter == 0)
 			break;
 		if (((slotptr->id & ~LAST_LONG_ENTRY_MASK) & 0xff) != counter)
@@ -796,10 +804,11 @@ get_vfatname (fsdata *mydata, int curclust, __u8 *cluster,
 		counter--;
 	}
 
-	if ((__u8 *)slotptr >= nextclust) {
+	if ((__u8 *)slotptr >= buflimit) {
 		dir_slot *slotptr2;
 
-		slotptr--;
+		if (curclust == 0)
+			return -1;
 		curclust = get_fatent(mydata, curclust);
 		if (CHECK_CLUST(curclust, mydata->fatsize)) {
 			debug("curclust: 0x%x\n", curclust);
@@ -814,14 +823,19 @@ get_vfatname (fsdata *mydata, int curclust, __u8 *cluster,
 		}
 
 		slotptr2 = (dir_slot *)get_vfatname_block;
-		while (slotptr2->id > 0x01)
+		while (counter > 0) {
+			if (((slotptr2->id & ~LAST_LONG_ENTRY_MASK)
+			    & 0xff) != counter)
+				return -1;
 			slotptr2++;
+			counter--;
+		}
 
 		/* Save the real directory entry */
-		realdent = (dir_entry *)slotptr2 + 1;
-		while ((__u8 *)slotptr2 >= get_vfatname_block) {
-			slot2str(slotptr2, l_name, &idx);
+		realdent = (dir_entry *)slotptr2;
+		while ((__u8 *)slotptr2 > get_vfatname_block) {
 			slotptr2--;
+			slot2str(slotptr2, l_name, &idx);
 		}
 	} else {
 		/* Save the real directory entry */
@@ -893,7 +907,7 @@ static dir_entry *get_dentfromdir (fsdata *mydata, int startsect,
 		dentptr = (dir_entry *)get_dentfromdir_block;
 
 		for (i = 0; i < DIRENTSPERCLUST; i++) {
-			char s_name[14], l_name[256];
+			char s_name[14], l_name[VFAT_MAXLEN_BYTES];
 
 			l_name[0] = '\0';
 			if (dentptr->name[0] == DELETED_FLAG) {
@@ -1196,7 +1210,11 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 		debug("FAT read sect=%d, clust_size=%d, DIRENTSPERBLOCK=%d\n",
 			cursect, mydata->clust_size, DIRENTSPERBLOCK);
 
-		if (disk_read(cursect, mydata->clust_size, do_fat_read_block) < 0) {
+		if (disk_read(cursect,
+				(mydata->fatsize == 32) ?
+				(mydata->clust_size) :
+				LINEAR_PREFETCH_SIZE,
+				do_fat_read_block) < 0) {
 			debug("Error: reading rootdir block\n");
 			return -1;
 		}
@@ -1204,9 +1222,13 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 		dentptr = (dir_entry *) do_fat_read_block;
 
 		for (i = 0; i < DIRENTSPERBLOCK; i++) {
-			char s_name[14], l_name[256];
+			char s_name[14], l_name[VFAT_MAXLEN_BYTES];
 
 			l_name[0] = '\0';
+			if (dentptr->name[0] == DELETED_FLAG) {
+				dentptr++;
+				continue;
+			}
 			if ((dentptr->attr & ATTR_VOLUME)) {
 #ifdef CONFIG_SUPPORT_VFAT
 				if ((dentptr->attr & ATTR_VFAT) == ATTR_VFAT &&
@@ -1214,7 +1236,10 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 					prevcksum =
 						((dir_slot *)dentptr)->alias_checksum;
 
-					get_vfatname(mydata, 0,
+					get_vfatname(mydata,
+						     (mydata->fatsize == 32) ?
+						     root_cluster :
+						     0,
 						     do_fat_read_block,
 						     dentptr, l_name);
 

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -1135,7 +1135,7 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 	volume_info volinfo;
 	fsdata datablock;
 	fsdata *mydata = &datablock;
-	dir_entry *dentptr;
+	dir_entry *dentptr = NULL;
 	__u16 prevcksum = 0xffff;
 	char *subname = "";
 	__u32 cursect;
@@ -1229,19 +1229,21 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 	while (1) {
 		int i;
 
-		debug("FAT read sect=%d, clust_size=%d, DIRENTSPERBLOCK=%d\n",
-			cursect, mydata->clust_size, DIRENTSPERBLOCK);
+		if (j == 0) {
+			debug("FAT read sect=%d, clust_size=%d, DIRENTSPERBLOCK=%zd\n",
+				cursect, mydata->clust_size, DIRENTSPERBLOCK);
 
-		if (disk_read(cursect,
-				(mydata->fatsize == 32) ?
-				(mydata->clust_size) :
-				PREFETCH_BLOCKS,
-				do_fat_read_block) < 0) {
-			debug("Error: reading rootdir block\n");
-			goto exit;
+			if (disk_read(cursect,
+					(mydata->fatsize == 32) ?
+					(mydata->clust_size) :
+					PREFETCH_BLOCKS,
+					do_fat_read_block) < 0) {
+				debug("Error: reading rootdir block\n");
+				goto exit;
+			}
+
+			dentptr = (dir_entry *) do_fat_read_block;
 		}
-
-		dentptr = (dir_entry *) do_fat_read_block;
 
 		for (i = 0; i < DIRENTSPERBLOCK; i++) {
 			char s_name[14], l_name[VFAT_MAXLEN_BYTES];
@@ -1385,28 +1387,33 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 		 * completely processed.
 		 */
 		++j;
-		int fat32_end = 0;
-		if ((mydata->fatsize == 32) && (j == mydata->clust_size)) {
-			int nxtsect = 0;
-			int nxt_clust = 0;
+		int rootdir_end = 0;
+		if (mydata->fatsize == 32) {
+			if (j == mydata->clust_size) {
+				int nxtsect = 0;
+				int nxt_clust = 0;
 
-			nxt_clust = get_fatent(mydata, root_cluster);
-			fat32_end = CHECK_CLUST(nxt_clust, 32);
+				nxt_clust = get_fatent(mydata, root_cluster);
+				rootdir_end = CHECK_CLUST(nxt_clust, 32);
 
-			nxtsect = mydata->data_begin +
-				(nxt_clust * mydata->clust_size);
+				nxtsect = mydata->data_begin +
+					(nxt_clust * mydata->clust_size);
 
-			root_cluster = nxt_clust;
+				root_cluster = nxt_clust;
 
-			cursect = nxtsect;
-			j = 0;
+				cursect = nxtsect;
+				j = 0;
+			}
 		} else {
-			cursect++;
+			if (j == PREFETCH_BLOCKS)
+				j = 0;
+
+			rootdir_end = (++cursect - mydata->rootdir_sect >=
+				       rootdir_size);
 		}
 
 		/* If end of rootdir reached */
-		if ((mydata->fatsize == 32 && fat32_end) ||
-		    (mydata->fatsize != 32 && j == rootdir_size)) {
+		if (rootdir_end) {
 			if (dols == LS_ROOT) {
 				printf("\n%d file(s), %d dir(s)\n\n",
 				       files, dirs);

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -558,8 +558,8 @@ static __u32 get_fatent (fsdata *mydata, __u32 entry)
 		__u32 fatlength = mydata->fatlength;
 		__u32 startblock = bufnum * FATBUFBLOCKS;
 
-		if (getsize > fatlength)
-			getsize = fatlength;
+		if (startblock + getsize > fatlength)
+			getsize = fatlength - startblock;
 
 		fatlength *= mydata->sect_size;	/* We want it in bytes now */
 		startblock += mydata->fat_sect;	/* Offset from start of disk */

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -974,6 +974,7 @@ static dir_entry *get_dentfromdir (fsdata *mydata, int startsect,
 			}
 #ifdef CONFIG_SUPPORT_VFAT
 			if (dols && mkcksum(dentptr->name) == prevcksum) {
+				prevcksum = 0xffff;
 				dentptr++;
 				continue;
 			}
@@ -1317,6 +1318,7 @@ do_fat_read (const char *filename, void *buffer, unsigned long maxsize,
 #ifdef CONFIG_SUPPORT_VFAT
 			else if (dols == LS_ROOT &&
 				 mkcksum(dentptr->name) == prevcksum) {
+				prevcksum = 0xffff;
 				dentptr++;
 				continue;
 			}

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -1453,11 +1453,11 @@ rootdir_done:
 			goto exit;
 		}
 
-		if (idx >= 0) {
-			if (!(dentptr->attr & ATTR_DIR))
-				goto exit;
+		if (isdir && !(dentptr->attr & ATTR_DIR))
+			goto exit;
+
+		if (idx >= 0)
 			subname = nextname;
-		}
 	}
 	if(buffer) {
 		ret = get_contents(mydata, dentptr, buffer, maxsize);

--- a/fs/fat/fat.c
+++ b/fs/fat/fat.c
@@ -916,8 +916,8 @@ static dir_entry *get_dentfromdir (fsdata *mydata, int startsect,
 			}
 			if ((dentptr->attr & ATTR_VOLUME)) {
 #ifdef CONFIG_SUPPORT_VFAT
-				if ((dentptr->attr & ATTR_VFAT) &&
-				    (dentptr-> name[0] & LAST_LONG_ENTRY_MASK)) {
+				if ((dentptr->attr & ATTR_VFAT) == ATTR_VFAT &&
+				    (dentptr->name[0] & LAST_LONG_ENTRY_MASK)) {
 					prevcksum = ((dir_slot *)dentptr)->alias_checksum;
 					get_vfatname(mydata, curclust,
 						     get_dentfromdir_block,

--- a/fs/fat/file.c
+++ b/fs/fat/file.c
@@ -48,11 +48,11 @@ char file_cwd[CWD_LEN+1] = "/";
 const char *
 file_getfsname(int idx)
 {
-	if (idx < 0 || idx >= NUM_FILESYS) return NULL;
+	if (idx < 0 || idx >= NUM_FILESYS)
+		return NULL;
 
 	return filesystems[idx].name;
 }
-
 
 static void
 pathcpy(char *dest, const char *src)
@@ -72,14 +72,13 @@ pathcpy(char *dest, const char *src)
 			return;
 		}
 		++dest;
-		if (ISDIRDELIM(*src)) {
+
+		if (ISDIRDELIM(*src))
 			while (ISDIRDELIM(*src)) src++;
-		} else {
+		else
 			src++;
-		}
 	} while (1);
 }
-
 
 int
 file_cd(const char *path)
@@ -141,7 +140,6 @@ file_cd(const char *path)
 	return 0;
 }
 
-
 int
 file_detectfs(void)
 {
@@ -159,7 +157,6 @@ file_detectfs(void)
 
 	return current_filesystem;
 }
-
 
 int
 file_ls(const char *dir)
@@ -180,7 +177,6 @@ file_ls(const char *dir)
 	}
 	return filesystems[current_filesystem].ls(arg);
 }
-
 
 long
 file_read(const char *filename, void *buffer, unsigned long maxsize)

--- a/include/fat.h
+++ b/include/fat.h
@@ -30,6 +30,10 @@
 #include <asm/byteorder.h>
 
 #define CONFIG_SUPPORT_VFAT
+/* Maximum Long File Name length supported here is 128 UTF-16 code units */
+#define VFAT_MAXLEN_BYTES	256 /* Maximum LFN buffer in bytes */
+#define VFAT_MAXSEQ		9   /* Up to 9 of 13 2-byte UTF-16 entries */
+#define LINEAR_PREFETCH_SIZE	(SECTOR_SIZE*2) /* Prefetch buffer size */
 
 #define SECTOR_SIZE FS_BLOCK_SIZE
 

--- a/include/fat.h
+++ b/include/fat.h
@@ -33,7 +33,7 @@
 /* Maximum Long File Name length supported here is 128 UTF-16 code units */
 #define VFAT_MAXLEN_BYTES	256 /* Maximum LFN buffer in bytes */
 #define VFAT_MAXSEQ		9   /* Up to 9 of 13 2-byte UTF-16 entries */
-#define LINEAR_PREFETCH_SIZE	(mydata->sect_size*2) /* Prefetch buffer size */
+#define PREFETCH_BLOCKS		2
 #define BYTE_PER_SEC	(dev_desc->blksz)
 #define RESERVED_CNT	32
 

--- a/include/fat.h
+++ b/include/fat.h
@@ -33,24 +33,17 @@
 /* Maximum Long File Name length supported here is 128 UTF-16 code units */
 #define VFAT_MAXLEN_BYTES	256 /* Maximum LFN buffer in bytes */
 #define VFAT_MAXSEQ		9   /* Up to 9 of 13 2-byte UTF-16 entries */
-#define LINEAR_PREFETCH_SIZE	(SECTOR_SIZE*2) /* Prefetch buffer size */
-
-#define SECTOR_SIZE FS_BLOCK_SIZE
-
-#define FS_BLOCK_SIZE	512
-#define BYTE_PER_SEC	512
+#define LINEAR_PREFETCH_SIZE	(mydata->sect_size*2) /* Prefetch buffer size */
+#define BYTE_PER_SEC	(dev_desc->blksz)
 #define RESERVED_CNT	32
 
-#if FS_BLOCK_SIZE != SECTOR_SIZE
-#error FS_BLOCK_SIZE != SECTOR_SIZE - This code needs to be fixed!
-#endif
-
 #define MAX_CLUSTSIZE	65536
-#define DIRENTSPERBLOCK	(FS_BLOCK_SIZE/sizeof(dir_entry))
-#define DIRENTSPERCLUST	((mydata->clust_size*SECTOR_SIZE)/sizeof(dir_entry))
+#define DIRENTSPERBLOCK	(mydata->sect_size / sizeof(dir_entry))
+#define DIRENTSPERCLUST	((mydata->clust_size * mydata->sect_size) / \
+			 sizeof(dir_entry))
 
 #define FATBUFBLOCKS	6
-#define FATBUFSIZE	(FS_BLOCK_SIZE*FATBUFBLOCKS)
+#define FATBUFSIZE	(mydata->sect_size * FATBUFBLOCKS)
 #define FAT12BUFSIZE	((FATBUFSIZE*2)/3)
 #define FAT16BUFSIZE	(FATBUFSIZE/2)
 #define FAT32BUFSIZE	(FATBUFSIZE/4)
@@ -236,11 +229,12 @@ typedef struct dir_slot {
  * (see FAT32 accesses)
  */
 typedef struct {
-	__u8	fatbuf[FATBUFSIZE]; /* Current FAT buffer */
+	__u8	*fatbuf;	/* Current FAT buffer */
 	int	fatsize;	/* Size of FAT in bits */
 	__u16	fatlength;	/* Length of FAT in sectors */
 	__u16	fat_sect;	/* Starting sector of the FAT */
 	__u16	rootdir_sect;	/* Start sector of root directory */
+	__u16	sect_size;	/* Size of sectors in bytes */
 	__u16	clust_size;	/* Size of clusters in sectors */
 	short	data_begin;	/* The sector of the first cluster, can be negative */
 	int	fatbufnum;	/* Used by get_fatent, init to -1 */

--- a/include/fat.h
+++ b/include/fat.h
@@ -33,9 +33,9 @@
 
 #define SECTOR_SIZE FS_BLOCK_SIZE
 
-#define FS_BLOCK_SIZE 512
-#define BYTE_PER_SEC  512
-#define RESERVED_CNT  32
+#define FS_BLOCK_SIZE	512
+#define BYTE_PER_SEC	512
+#define RESERVED_CNT	32
 
 #if FS_BLOCK_SIZE != SECTOR_SIZE
 #error FS_BLOCK_SIZE != SECTOR_SIZE - This code needs to be fixed!
@@ -59,37 +59,31 @@
 #define SIGNLEN		8
 
 /* File attributes */
-#define ATTR_RO      1
-#define ATTR_HIDDEN  2
-#define ATTR_SYS     4
-#define ATTR_VOLUME  8
-#define ATTR_DIR     16
-#define ATTR_ARCH    32
+#define ATTR_RO	1
+#define ATTR_HIDDEN	2
+#define ATTR_SYS	4
+#define ATTR_VOLUME	8
+#define ATTR_DIR	16
+#define ATTR_ARCH	32
 
-#define ATTR_VFAT     (ATTR_RO | ATTR_HIDDEN | ATTR_SYS | ATTR_VOLUME)
+#define ATTR_VFAT	(ATTR_RO | ATTR_HIDDEN | ATTR_SYS | ATTR_VOLUME)
 
 #define DELETED_FLAG	((char)0xe5) /* Marks deleted files when in name[0] */
 #define aRING		0x05	     /* Used as special character in name[0] */
 
-/* Indicates that the entry is the last long entry in a set of long
+/*
+ * Indicates that the entry is the last long entry in a set of long
  * dir entries
  */
 #define LAST_LONG_ENTRY_MASK	0x40
 
 /* Flags telling whether we should read a file or list a directory */
-#define LS_NO	0
-#define LS_YES	1
-#define LS_DIR	1
-#define LS_ROOT	2
+#define LS_NO		0
+#define LS_YES		1
+#define LS_DIR		1
+#define LS_ROOT		2
 
-#ifdef DEBUG
-#define FAT_DPRINT(args...)	printf(args)
-#else
-#define FAT_DPRINT(args...)
-#endif
-#define FAT_ERROR(arg)		printf(arg)
-
-#define ISDIRDELIM(c)   ((c) == '/' || (c) == '\\')
+#define ISDIRDELIM(c)	((c) == '/' || (c) == '\\')
 
 #define FSTYPE_NONE	(-1)
 
@@ -221,17 +215,18 @@ typedef struct dir_entry {
 } dir_entry;
 
 typedef struct dir_slot {
-	__u8    id;		/* Sequence number for slot */
-	__u8    name0_4[10];	/* First 5 characters in name */
-	__u8    attr;		/* Attribute byte */
-	__u8    reserved;	/* Unused */
-	__u8    alias_checksum;/* Checksum for 8.3 alias */
-	__u8    name5_10[12];	/* 6 more characters in name */
-	__u16   start;		/* Unused */
-	__u8    name11_12[4];	/* Last 2 characters in name */
+	__u8	id;		/* Sequence number for slot */
+	__u8	name0_4[10];	/* First 5 characters in name */
+	__u8	attr;		/* Attribute byte */
+	__u8	reserved;	/* Unused */
+	__u8	alias_checksum;/* Checksum for 8.3 alias */
+	__u8	name5_10[12];	/* 6 more characters in name */
+	__u16	start;		/* Unused */
+	__u8	name11_12[4];	/* Last 2 characters in name */
 } dir_slot;
 
-/* Private filesystem parameters
+/*
+ * Private filesystem parameters
  *
  * Note: FAT buffer has to be 32 bit aligned
  * (see FAT32 accesses)
@@ -253,10 +248,10 @@ typedef long	(file_read_func)(const char *filename, void *buffer,
 				 unsigned long maxsize);
 
 struct filesystem {
-	file_detectfs_func *detect;
-	file_ls_func	   *ls;
-	file_read_func	   *read;
-	const char	    name[12];
+	file_detectfs_func	*detect;
+	file_ls_func		*ls;
+	file_read_func		*read;
+	const char		name[12];
 };
 
 /* FAT tables */


### PR DESCRIPTION
This contains back-ports of various fixes to the fs/fat code from mainline u-boot.
I included the "big code cleanup" one just so that later commits would cherry-pick more cleanly.

With these changes, u-boot-odroid can now load the kernel and dtb from recent netbsd armv7.img images again.